### PR TITLE
Added a warning to lab 4.2 for when a non-accepted string causes the machine complete a computation successfully, run forever or go off the tape.

### DIFF
--- a/app/controllers/Lab42TestRunner.java
+++ b/app/controllers/Lab42TestRunner.java
@@ -25,7 +25,8 @@ public class Lab42TestRunner extends AbstractTestRunner<Lab42RunResult>
         }
         catch (Exception e)
         {
-            boolean halted;
+            boolean halted, parked;
+
             try
             {
                 halted = sim.isHalted();
@@ -35,7 +36,18 @@ public class Lab42TestRunner extends AbstractTestRunner<Lab42RunResult>
                 halted = false;
             }
 
-            return new Lab42RunResult(e.getMessage(), exp, input, false, halted, sim.getTape().isParked(), "-");
+            if (e instanceof TapeBoundsException)
+            {
+                // Going off the edge of the tape clearly isn't parked (but the tape will think it is, so it must be
+                // manually set to false)
+                parked = false;
+            }
+            else
+            {
+                parked = sim.getTape().isParked();
+            }
+
+            return new Lab42RunResult(e.getMessage(), exp, input, false, halted, parked, "-");
         }
     }
 }

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -16,7 +16,7 @@
         @content
 
         <footer>
-            <span class="right"> <em>Last Updated: 25/09/2015</em></span>
+            <span class="right"> <em>Last Updated: 01/10/2015</em></span>
             <span class="clear"> Problems?
                 Please send an email to <a href="mailto:comp235labs@@gmail.com">comp235labs@@gmail.com</a>.
             </span>


### PR DESCRIPTION
Lab 4 calls for inputs that don't give an answer to "terminate without completing a computation". I've double checked, and running forever, running off the left edge, or  ending in an accepting state with the head parked are not acceptable ways of doing this. The verifier should now show a warning for all these cases on inputs where the output doesn't matter.

Also fixed bug where the output displayed that the machine had halted if it ran for >= maxsteps.
